### PR TITLE
Fix: fallbacks on other score computation when an entry is too old

### DIFF
--- a/spec/sort.test.js
+++ b/spec/sort.test.js
@@ -364,5 +364,82 @@ describe('frecency', () => {
         groupName: 'testing group'
       }]);
     });
+
+    it('fallbacks on subquery matching when query entry is too old (> 14 days)', () => {
+      const frecency = new Frecency({ key: 'templates' });
+      const now = 1524085045510;
+
+      global.Date.now = jest.fn(() => now - 15 * day);
+      frecency.save({
+        searchQuery: 'br',
+        selectedId: 'brad neuberg'
+      });
+
+      global.Date.now = jest.fn(() => now - 2 * day);
+      frecency.save({
+        searchQuery: 'brad',
+        selectedId: 'brad neuberg'
+      });
+
+      global.Date.now = jest.fn(() => now);
+
+      const results = frecency.sort({
+        searchQuery: 'br',
+        results: [{
+          _id: 'brad vogel'
+        }, {
+          _id: 'simon xiong'
+        }, {
+          _id: 'brad neuberg'
+        }]
+      });
+
+      expect(results).toEqual([{
+        _id: 'brad neuberg'
+      }, {
+        _id: 'brad vogel'
+      }, {
+        _id: 'simon xiong'
+      }]);
+    });
+
+
+    it('fallbacks on recent selections matching when queries/subqueries are too old (> 14 days)', () => {
+      const frecency = new Frecency({ key: 'templates' });
+      const now = 1524085045510;
+
+      global.Date.now = jest.fn(() => now - 15 * day);
+      frecency.save({
+        searchQuery: 'brad',
+        selectedId: 'brad neuberg'
+      });
+
+      global.Date.now = jest.fn(() => now - 2 * day);
+      frecency.save({
+        searchQuery: 'bra',
+        selectedId: 'brad neuberg'
+      });
+
+      global.Date.now = jest.fn(() => now);
+
+      const results = frecency.sort({
+        searchQuery: 'brad',
+        results: [{
+          _id: 'brad vogel'
+        }, {
+          _id: 'simon xiong'
+        }, {
+          _id: 'brad neuberg'
+        }]
+      });
+
+      expect(results).toEqual([{
+        _id: 'brad neuberg'
+      }, {
+        _id: 'brad vogel'
+      }, {
+        _id: 'simon xiong'
+      }]);
+    });
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -294,7 +294,7 @@ class Frecency {
         if (selection) {
           result._frecencyScore = this._calculateScore(selection.selectedAt,
             selection.timesSelected, now);
-          return;
+          if (result._frecencyScore > 0) return;
         }
       }
 
@@ -313,7 +313,7 @@ class Frecency {
           // Reduce the score because this is not an exact query match.
           result._frecencyScore = 0.7 * this._calculateScore(selection.selectedAt,
             selection.timesSelected, now);
-          return;
+          if (result._frecencyScore > 0) return;
         }
       }
 


### PR DESCRIPTION
Hi,

I have an issue when 2 timestamps overlap the 14 days limit.

- I added 2 tests which confirm my issue.
- I added 2 lines of code to avoid early return when computed score is equals to zero.

Is that enough comprehensible ?
Do you need more infos or tests ?
