### PR TITLE
Feat: make weights configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,3 +138,16 @@ new Frecency({
   storageProvider
 });
 ```
+
+### Configure weights
+
+Differents weights are applied depending on what kind of match it is about
+
+```js
+new Frecency({
+  key: 'people',
+  exactQueryWeight: 0.9, // default to 1.0
+  subQueryWeight: 0.5, // default to 0.7
+  recentWeight: 0.1, // default to 0.5
+});
+```

--- a/README.md
+++ b/README.md
@@ -146,8 +146,8 @@ Differents weights are applied depending on what kind of match it is about
 ```js
 new Frecency({
   key: 'people',
-  exactQueryWeight: 0.9, // default to 1.0
-  subQueryWeight: 0.5, // default to 0.7
-  recentWeight: 0.1, // default to 0.5
+  exactQueryMatchWeight: 0.9, // default to 1.0
+  subQueryMatchWeight: 0.5, // default to 0.7
+  recentSelectionsMatchWeight: 0.1, // default to 0.5
 });
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,11 @@ class Frecency {
   _storageProvider: ?StorageProvider;
   _frecency: FrecencyData;
 
-  constructor({ key, timestampsLimit, recentSelectionsLimit, idAttribute, storageProvider }: FrecencyOptions) {
+  _exactQueryMatchWeight: number;
+  _subQueryWeight: number;
+  _recentWeight: number;
+
+  constructor({ key, timestampsLimit, recentSelectionsLimit, idAttribute, storageProvider, exactQueryMatchWeight, subQueryWeight, recentWeight }: FrecencyOptions) {
     if (!key) throw new Error('key is required.');
 
     this._key = key;
@@ -28,6 +32,9 @@ class Frecency {
     this._idAttribute = idAttribute || '_id';
     this._storageProvider = loadStorageProvider(storageProvider);
     this._localStorageEnabled = Boolean(this._storageProvider);
+    this._exactQueryMatchWeight = exactQueryMatchWeight || 1.0;
+    this._subQueryWeight = subQueryWeight || 0.7;
+    this._recentWeight = subQueryWeight || 0.5;
 
     this._frecency = this._getFrecencyData();
   }
@@ -292,7 +299,7 @@ class Frecency {
         });
 
         if (selection) {
-          result._frecencyScore = this._calculateScore(selection.selectedAt,
+          result._frecencyScore = this._exactQueryMatchWeight * this._calculateScore(selection.selectedAt,
             selection.timesSelected, now);
           return;
         }
@@ -311,7 +318,7 @@ class Frecency {
 
         if (selection) {
           // Reduce the score because this is not an exact query match.
-          result._frecencyScore = 0.7 * this._calculateScore(selection.selectedAt,
+          result._frecencyScore = this._subQueryWeight * this._calculateScore(selection.selectedAt,
             selection.timesSelected, now);
           return;
         }
@@ -321,7 +328,7 @@ class Frecency {
       const selection = this._frecency.selections[resultId];
       if (selection) {
         // Reduce the score because this is not an exact query match.
-        result._frecencyScore = 0.5 * this._calculateScore(selection.selectedAt,
+        result._frecencyScore = this._recentWeight * this._calculateScore(selection.selectedAt,
           selection.timesSelected, now);
         return;
       }

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ class Frecency {
     this._localStorageEnabled = Boolean(this._storageProvider);
     this._exactQueryMatchWeight = exactQueryMatchWeight || 1.0;
     this._subQueryWeight = subQueryWeight || 0.7;
-    this._recentWeight = subQueryWeight || 0.5;
+    this._recentWeight = recentWeight || 0.5;
 
     this._frecency = this._getFrecencyData();
   }

--- a/src/index.js
+++ b/src/index.js
@@ -20,10 +20,10 @@ class Frecency {
   _frecency: FrecencyData;
 
   _exactQueryMatchWeight: number;
-  _subQueryWeight: number;
-  _recentWeight: number;
+  _subQueryMatchWeight: number;
+  _recentSelectionsMatchWeight: number;
 
-  constructor({ key, timestampsLimit, recentSelectionsLimit, idAttribute, storageProvider, exactQueryMatchWeight, subQueryWeight, recentWeight }: FrecencyOptions) {
+  constructor({ key, timestampsLimit, recentSelectionsLimit, idAttribute, storageProvider, exactQueryMatchWeight, subQueryMatchWeight, recentSelectionsMatchWeight }: FrecencyOptions) {
     if (!key) throw new Error('key is required.');
 
     this._key = key;
@@ -33,8 +33,8 @@ class Frecency {
     this._storageProvider = loadStorageProvider(storageProvider);
     this._localStorageEnabled = Boolean(this._storageProvider);
     this._exactQueryMatchWeight = exactQueryMatchWeight || 1.0;
-    this._subQueryWeight = subQueryWeight || 0.7;
-    this._recentWeight = recentWeight || 0.5;
+    this._subQueryMatchWeight = subQueryMatchWeight || 0.7;
+    this._recentSelectionsMatchWeight = recentSelectionsMatchWeight || 0.5;
 
     this._frecency = this._getFrecencyData();
   }
@@ -318,7 +318,7 @@ class Frecency {
 
         if (selection) {
           // Reduce the score because this is not an exact query match.
-          result._frecencyScore = this._subQueryWeight * this._calculateScore(selection.selectedAt,
+          result._frecencyScore = this._subQueryMatchWeight * this._calculateScore(selection.selectedAt,
             selection.timesSelected, now);
           return;
         }
@@ -328,7 +328,7 @@ class Frecency {
       const selection = this._frecency.selections[resultId];
       if (selection) {
         // Reduce the score because this is not an exact query match.
-        result._frecencyScore = this._recentWeight * this._calculateScore(selection.selectedAt,
+        result._frecencyScore = this._recentSelectionsMatchWeight * this._calculateScore(selection.selectedAt,
           selection.timesSelected, now);
         return;
       }

--- a/src/types.js
+++ b/src/types.js
@@ -58,9 +58,9 @@ export type FrecencyOptions = {
   recentSelectionsLimit?: number,
   idAttribute?: string | Function,
   storageProvider?: StorageProvider,
-  exactQueryWeight?: number,
-  subQueryWeight?: number,
-  recentWeight?: number,
+  exactQueryMatchWeight?: number,
+  subQueryMatchWeight?: number,
+  recentSelectionsMatchWeight?: number,
 };
 
 export type SaveParams = {

--- a/src/types.js
+++ b/src/types.js
@@ -57,7 +57,10 @@ export type FrecencyOptions = {
   timestampsLimit?: number,
   recentSelectionsLimit?: number,
   idAttribute?: string | Function,
-  storageProvider?: StorageProvider
+  storageProvider?: StorageProvider,
+  exactQueryWeight?: number,
+  subQueryWeight?: number,
+  recentWeight?: number,
 };
 
 export type SaveParams = {


### PR DESCRIPTION
There are 3 different configurable weights : 
- **exactQueryMatchWeight** (default to `1.0`)
- **subQueryMatchWeight** (default to `0.7`)
- **recentSelectionsMatchWeight** (default to `0.5`)