### PR TITLE
fix(import): use relative paths to support webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "frecency",
   "version": "1.3.1",
   "description": "Frecency sorting for search results.",
-  "main": "dist/main.js",
+  "main": "./dist/main.js",
   "browser": {
-    "./index.js": "dist/browser.js"
+    "./index.js": "./dist/browser.js"
   },
   "files": [
     "dist",


### PR DESCRIPTION
Webpack requires relative paths for resolving modules. This updates the package file so webpack can resolve imports correctly.