### PR TITLE
[ETF-565] computeScore method + ts support

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,15 @@
+module.exports = {
+  semi: true,
+  trailingComma: 'all',
+  singleQuote: true,
+  printWidth: 120,
+  tabWidth: 2,
+  overrides: [
+    {
+      files: '*.json',
+      options: {
+        printWidth: 80,
+      },
+    },
+  ],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1272,6 +1272,16 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "boom": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
@@ -2471,6 +2481,13 @@
         "object-assign": "^4.0.1"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
@@ -2591,552 +2608,10 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "nan": "^2.9.2",
-        "node-pre-gyp": "^0.10.0"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "aproba": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
-          }
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "chownr": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "debug": {
-          "version": "2.6.9",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "deep-extend": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "detect-libc": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "fs-minipass": {
-          "version": "1.2.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^2.2.1"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "iconv-lite": {
-          "version": "0.4.21",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safer-buffer": "^2.1.0"
-          }
-        },
-        "ignore-walk": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minimatch": "^3.0.4"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ini": {
-          "version": "1.3.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "minipass": {
-          "version": "2.2.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^2.2.1"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "needle": {
-          "version": "2.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "debug": "^2.1.2",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
-          }
-        },
-        "node-pre-gyp": {
-          "version": "0.10.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
-          }
-        },
-        "npm-bundled": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "npm-packlist": {
-          "version": "1.1.10",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.7",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "^0.5.1",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "glob": "^7.0.5"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "safer-buffer": {
-          "version": "2.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "sax": {
-          "version": "1.2.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "semver": {
-          "version": "5.5.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "4.4.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "chownr": "^1.0.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.2.4",
-            "minizlib": "^1.1.0",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.2"
-          }
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "wide-align": {
-          "version": "1.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "string-width": "^1.0.2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "yallist": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        }
-      }
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "dev": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -5434,9 +4909,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
       "dev": true,
       "optional": true
     },
@@ -6532,6 +6007,17 @@
         "watch": "~0.18.0"
       },
       "dependencies": {
+        "fsevents": {
+          "version": "1.2.13",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+          "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
+        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -7193,6 +6679,12 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "typescript": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.6.tgz",
+      "integrity": "sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -182,6 +182,7 @@
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
       "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "esutils": "^2.0.2",
         "lodash": "^4.2.0",
@@ -192,7 +193,8 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
           "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -281,6 +283,7 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -292,6 +295,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -2606,7 +2610,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2627,12 +2632,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2647,17 +2654,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2774,7 +2784,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2786,6 +2797,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2800,6 +2812,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2807,12 +2820,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2831,6 +2846,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2911,7 +2927,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2923,6 +2940,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3008,7 +3026,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3044,6 +3063,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3063,6 +3083,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3106,12 +3127,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -5226,7 +5249,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "loose-envify": {
       "version": "1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "frecency",
-  "version": "1.3.1",
+  "name": "@getstation/frecency",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "frecency",
+  "name": "@getstation/frecency",
   "version": "1.4.0",
   "description": "Frecency sorting for search results.",
   "main": "dist/main.js",

--- a/package.json
+++ b/package.json
@@ -10,14 +10,19 @@
     "dist",
     "src"
   ],
+  "types": "types/index.d.ts",
   "scripts": {
     "ci": "npm run lint && npm run build",
-    "lint": "eslint . && flow",
+    "lint": "eslint .",
+    "lint:flow": "flow",
+    "tsc": "tsc --noEmit -p .",
+    "lint:all": "yarn run lint && yarn run lint:flow && yarn run tsc",
     "prebuild": "rm -rf dist/",
     "build": "[ \"$WATCH\" == 'true' ] && rollup -cw || rollup -c",
     "test": "npm run build && jest",
+    "test:all": "npm run lint:all && npm run test",
     "watch": "WATCH=true yarn build",
-    "prepublish": "npm run lint && npm run build && npm test"
+    "prepublishOnly": "npm run test:all && npm run build"
   },
   "repository": {
     "type": "git",
@@ -39,9 +44,11 @@
     "eslint-config-mixmax": "^1.0.0",
     "eslint-plugin-flowtype": "^2.46.1",
     "flow-bin": "^0.75.0",
+    "fsevents": "^2.1.3",
     "jest": "^22.4.3",
     "rollup": "^0.57.1",
     "rollup-plugin-babel": "^2.6.1",
-    "rollup-plugin-replace": "^2.0.0"
+    "rollup-plugin-replace": "^2.0.0",
+    "typescript": "^3.9.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frecency",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Frecency sorting for search results.",
   "main": "dist/main.js",
   "browser": {

--- a/src/index.js
+++ b/src/index.js
@@ -42,13 +42,14 @@ class Frecency {
   /**
    * Updates frecency data after user selects a result.
    * @param {Object} params
-   *   @prop {String} searchQuery - The search query the user entered.
    *   @prop {String} selectedId - String representing the ID of the search result selected.
+   *   @prop {String} searchQuery - The search query the user entered.
+   *   @prop {Date} [dateSelection] - The date on which item has been selected.
    */
-  save({ searchQuery, selectedId }: SaveParams): void {
+  save({ searchQuery, selectedId, dateSelection }: SaveParams): void {
     if (!selectedId || !this._localStorageEnabled) return;
 
-    const now = Date.now();
+    const date = dateSelection ? dateSelection.getTime() : Date.now();
 
     // Reload frecency here to pick up frecency updates from other tabs.
     const frecency = this._getFrecencyData();
@@ -56,13 +57,13 @@ class Frecency {
     // Associate the selection with the search query used. This lets us sort this
     // selection higher when the user enters the search query again. See:
     // https://slack.engineering/a-faster-smarter-quick-switcher-77cbc193cb60#80de
-    this._updateFrecencyByQuery(frecency, searchQuery, selectedId, now);
+    this._updateFrecencyByQuery(frecency, searchQuery, selectedId, date);
 
     // Associate the selection with its ID. If the user doesn't enter the same search
     // query as before, but this selection shows up in the list of results, we still
     // want this selection to show up higher because it was recently selected. See:
     // https://slack.engineering/a-faster-smarter-quick-switcher-77cbc193cb60#700c
-    this._updateFrecencyById(frecency, searchQuery, selectedId, now);
+    this._updateFrecencyById(frecency, searchQuery, selectedId, date);
 
     this._cleanUpOldIds(frecency, selectedId);
     this._saveFrecencyData(frecency);
@@ -111,10 +112,10 @@ class Frecency {
    * @param {FrecencyData} frecency - Frecency object to be modified in place.
    * @param {String} searchQuery - Search query the user entered.
    * @param {String} selectedId - ID of search result the user selected.
-   * @param {Number} now - Current time in milliseconds.
+   * @param {Number} timestampSelection - Time in milliseconds.
    */
   _updateFrecencyByQuery(frecency: FrecencyData, searchQuery: ?string, selectedId: string,
-    now: number): void {
+    timestampSelection: number): void {
     if (!searchQuery) return;
 
     const queries = frecency.queries;
@@ -130,14 +131,14 @@ class Frecency {
       queries[searchQuery].push({
         id: selectedId,
         timesSelected: 1,
-        selectedAt: [now]
+        selectedAt: [timestampSelection]
       });
       return;
     }
 
     // Otherwise, increment the previous entry.
     previousSelection.timesSelected += 1;
-    previousSelection.selectedAt.push(now);
+    previousSelection.selectedAt.push(timestampSelection);
 
     // Limit the selections timestamps.
     if (previousSelection.selectedAt.length > this._timestampsLimit) {
@@ -150,10 +151,10 @@ class Frecency {
    * @param {FrecencyData} frecency - Frecency object to be modified in place.
    * @param {String} searchQuery - Search query the user entered.
    * @param {String} selectedId - ID of search result the user selected.
-   * @param {Number} now - Current time in milliseconds.
+   * @param {Number} timestampSelection - Time in milliseconds.
    */
   _updateFrecencyById(frecency: FrecencyData, searchQuery: ?string, selectedId: string,
-    now: number): void {
+    timestampSelection: number): void {
 
     const selections = frecency.selections;
     const previousSelection = selections[selectedId];
@@ -162,7 +163,7 @@ class Frecency {
     if (!previousSelection) {
       selections[selectedId] = {
         timesSelected: 1,
-        selectedAt: [now],
+        selectedAt: [timestampSelection],
         queries: {}
       };
 
@@ -172,7 +173,7 @@ class Frecency {
 
     // Otherwise, update the previous entry.
     previousSelection.timesSelected += 1;
-    previousSelection.selectedAt.push(now);
+    previousSelection.selectedAt.push(timestampSelection);
 
     // Limit the selections timestamps.
     if (previousSelection.selectedAt.length > this._timestampsLimit) {
@@ -342,21 +343,21 @@ class Frecency {
    * the total number of times selected, and the current time.
    * @param {Number[]} timestamps - Timestamps of recent selections.
    * @param {Number} timesSelected - Total number of times selected.
-   * @param {Number} now - Current time in milliseconds.
+   * @param {Number} timestampSelection - Time in milliseconds.
    * @return {Number} The calculated frecency score.
    */
-  _calculateScore(timestamps: number[], timesSelected: number, now: number): number {
+  _calculateScore(timestamps: number[], timesSelected: number, timestampSelection: number): number {
     if (timestamps.length === 0) return 0;
 
     const hour = 1000 * 60 * 60;
     const day = 24 * hour;
 
     const totalScore = timestamps.reduce((score, timestamp) => {
-      if (timestamp >= now - 3 * hour) return score + 100;
-      if (timestamp >= now - day) return score + 80;
-      if (timestamp >= now - 3 * day) return score + 60;
-      if (timestamp >= now - 7 * day) return score + 30;
-      if (timestamp >= now - 14 * day) return score + 10;
+      if (timestamp >= timestampSelection - 3 * hour) return score + 100;
+      if (timestamp >= timestampSelection - day) return score + 80;
+      if (timestamp >= timestampSelection - 3 * day) return score + 60;
+      if (timestamp >= timestampSelection - 7 * day) return score + 30;
+      if (timestamp >= timestampSelection - 14 * day) return score + 10;
       return score;
     }, 0);
 

--- a/src/types.js
+++ b/src/types.js
@@ -11,8 +11,8 @@ export type FrecencyData = {
 
       // The list of timestamps of the most recent selections, which will
       // be used to calculate relevance scores for each result.
-      selectedAt: number[]
-    }>;
+      selectedAt: number[],
+    }>,
   },
 
   // Stores information about how often a particular result has been chosen
@@ -23,7 +23,6 @@ export type FrecencyData = {
   //    to rank higher because "brad vogel" has been selected very often.
   selections: {
     [id: string]: {
-
       // Total times this result was chosen regardless of the user's search query.
       timesSelected: number,
 
@@ -33,24 +32,25 @@ export type FrecencyData = {
 
       // The set of queries where the user selected this result. Used when removing results
       // from the frecency data in order to limit the size of the frecency object.
-      queries: { [query: string]: true, }
+      queries: { [query: string]: true },
     },
   },
 
   // Cache of recently selected IDs (ordered from most to least recent). When an ID is
   // selected we'll add or shift the ID to the front. When this list exceeds a certain
   // limit, we'll remove the last ID and remove all frecency data for this ID.
-  recentSelections: string[];
+  recentSelections: string[],
 };
 
-export type StorageProvider = any & $ReadOnly<{
-  getItem: (key: string) => ?string,
-  setItem: (key: string, value: string) => void,
-  removeItem: (key: string) => void,
-  key: (n: number) => ?string,
-  clear: () => void,
-  length: number
-}>
+export type StorageProvider = any &
+  $ReadOnly<{
+    getItem: (key: string) => ?string,
+    setItem: (key: string, value: string) => void,
+    removeItem: (key: string) => void,
+    key: (n: number) => ?string,
+    clear: () => void,
+    length: number,
+  }>;
 
 export type FrecencyOptions = {
   key: string,
@@ -69,8 +69,14 @@ export type SaveParams = {
   dateSelection?: Date,
 };
 
+export type ComputeScoreParams = {
+  searchQuery: ?string,
+  item: Object,
+  now?: number,
+};
+
 export type SortParams = {
   searchQuery: ?string,
   results: Object[],
-  keepScores?: boolean
+  keepScores?: boolean,
 };

--- a/src/types.js
+++ b/src/types.js
@@ -64,8 +64,9 @@ export type FrecencyOptions = {
 };
 
 export type SaveParams = {
+  selectedId: string,
   searchQuery: ?string,
-  selectedId: string
+  dateSelection?: Date,
 };
 
 export type SortParams = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,73 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+    /* Basic Options */
+    // "incremental": true,                   /* Enable incremental compilation */
+    "target": "es6" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
+    "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
+    "lib": [
+      "dom",
+      "es2019"
+    ] /* Specify library files to be included in the compilation. */,
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    // "outDir": "./",                        /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                     /* Enable project compilation */
+    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true /* Enable all strict type-checking options. */,
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+
+    /* Advanced Options */
+    "skipLibCheck": false /* Skip type checking of declaration files. */,
+    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
+  },
+  "include": ["types/index.d.ts"]
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,7 +3,7 @@
 
 // TypeScript Version: 3.9
 
-declare module "@getstation/frecency" {
+declare module '@getstation/frecency' {
   export type idAttrFn = (result: string) => string;
 
   export type StorageProvider = {
@@ -23,17 +23,14 @@ declare module "@getstation/frecency" {
       subQueryMatchWeight?: number;
       recentSelectionsMatchWeight?: number;
     });
-    save: (arg: {
-      searchQuery: string;
-      selectedId: string;
-      dateSelection?: Date;
-    }) => void;
+    save: (params: { searchQuery: string; selectedId: string; dateSelection?: Date }) => void;
     sort:
-      | ((arg: { searchQuery: string; results: T[] }) => T[])
-      | ((arg: {
+      | ((params: { searchQuery: string; results: T[] }) => T[])
+      | ((params: {
           searchQuery: string;
           results: T[];
           keepScores?: boolean;
         }) => Array<T & { _frecencyScore?: number }>);
+    computeScore: (params: { searchQuery: string; item: T; now?: number }) => number;
   }
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,39 @@
+// Type definitions for @getstation/frecency 1.4
+// Project: https://github.com/getstation/frecency
+
+// TypeScript Version: 3.9
+
+declare module "@getstation/frecency" {
+  export type idAttrFn = (result: string) => string;
+
+  export type StorageProvider = {
+    getItem: (key: string) => string | null;
+    setItem: (key: string, value: string) => void;
+    removeItem: (key: string) => void;
+  };
+
+  export default class Frecency<T = any> {
+    constructor(constructOpts: {
+      key: string;
+      idAttribute?: string | idAttrFn;
+      timeStampsLimit?: number;
+      recentSelectionsLimit?: number;
+      storageProvider?: StorageProvider;
+      exactQueryMatchWeight?: number;
+      subQueryMatchWeight?: number;
+      recentSelectionsMatchWeight?: number;
+    });
+    save: (arg: {
+      searchQuery: string;
+      selectedId: string;
+      dateSelection?: Date;
+    }) => void;
+    sort:
+      | ((arg: { searchQuery: string; results: T[] }) => T[])
+      | ((arg: {
+          searchQuery: string;
+          results: T[];
+          keepScores?: boolean;
+        }) => Array<T & { _frecencyScore?: number }>);
+  }
+}


### PR DESCRIPTION
## What is this PR
It resolves ETF-565

## How does it works
- added basic prettier config
- added ts support
- add computeScore public method to be able to compute a score for one item


## Test instructions
- `npm install` (don't use yarn)
- `npm run test:all` should pass

## TODO
- [ ] PR linked to the linear task
- [ ] Update README
- [ ] when this PR is merged, make a new release on npm

